### PR TITLE
fix: add missing 'v' on version release link

### DIFF
--- a/website/app/components/sidebar/sidebarFooter.tsx
+++ b/website/app/components/sidebar/sidebarFooter.tsx
@@ -14,7 +14,7 @@ const SidebarFooter = ({ npmVersion }: iSidebar) => {
     <div className="w-full border-b-2 border-dashed border-neutral-200 py-2 text-sm dark:border-neutral-800">
       <div className="font-medium">
         <a
-          href={`https://github.com/pheralb/toast/releases/tag/${npmVersion}`}
+          href={`https://github.com/pheralb/toast/releases/tag/v${npmVersion}`}
           target="_blank"
           rel="noreferrer"
           className="group flex items-center py-1 text-neutral-600 transition-colors duration-100 hover:text-black dark:text-neutral-400 dark:decoration-neutral-700 dark:hover:text-white"


### PR DESCRIPTION
## Fix URL in Version Link to redirect to the correct release site (SidebarFooter)

### Description

This PR fixes the URL in the version link by adding a "v" before the current version.

### Before

The link redirects to `https://github.com/pheralb/toast/releases/tag/0.2.2` resulting in a 404 page.

![toast](https://github.com/user-attachments/assets/642c5fc9-e6f2-4b77-af70-f828f01271e6)

### After

The link redirects to `https://github.com/pheralb/toast/releases/tag/v0.2.2` resulting in the current release page.

![toast-fix](https://github.com/user-attachments/assets/d3480115-bb3a-4606-940a-3a600f9b79cb)
